### PR TITLE
fix check register runners detection

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+## v0.0.6
+
+- fix check register runners detection
+
 ## v0.0.5
 
 - fix role application in check mode

--- a/tasks/register-one-runner.yml
+++ b/tasks/register-one-runner.yml
@@ -22,7 +22,7 @@
     _env: "{% for e in _config.env|default([]) %} --env '{{e}}'{% endfor %}"
 
 - name: Check if runner already registered
-  shell: gitlab-ci-multi-runner list 2>&1 | egrep '^{{_config.name}}\s+'
+  shell: gitlab-ci-multi-runner list 2>&1 | sed -E 's/\s+?\x1B/|/g' | cut -d'|' -f1 | grep -x '{{_config.name}}'
   failed_when: false
   changed_when: false
   register: check_if_registered_result


### PR DESCRIPTION
For some runners output of `gitlab-ci-multi-runner list` may not contain space after runner name, it causes duplicates, see example:

```
$ gitlab-ci-multi-runner list 2>&1 | vim -
Listing configured runners                        ^[[0;m  ConfigFile^[[0;m=/etc/gitlab-runner/config.toml
Shell on popstas-server for molecule tests with Vagrant^[[0;m  Executor^[[0;m=shell Token ...
Shell on popstas-server for molecule tests with Vagrant^[[0;m  Executor^[[0;m=shell Token ...
Shell on popstas-server for molecule tests with Vagrant^[[0;m  Executor^[[0;m=shell Token ...
shell vagrant                                     ^[[0;m  Executor^[[0;m=shell Token ...
```

I change parsing method by replacing `\s+?^[` to `|`, then cut only runner name, then check whole line match.