### PR TITLE
Add support for Centos OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ The playbook was tested on following platforms:
 - Ubuntu 12.04
 - Ubuntu 14.04
 - Ubuntu 16.04
+- Centos 7
 
 ### Supported Executors
 
@@ -67,7 +68,6 @@ At the moment it is only:
 
 ### TODO
 
-- add support for CentOS
 - add integration tests
 - support more executors
 - make it possible to unregister existing runners

--- a/tasks/install-docker-on-debian-family.yml
+++ b/tasks/install-docker-on-debian-family.yml
@@ -1,0 +1,33 @@
+---
+# - name: Install docker
+#   shell: "wget -qO- https://get.docker.com/ | sh"
+
+- name: Install docker requirements
+  apt:
+    name: 
+      - apt-transport-https
+      - ca-certificates
+      - curl
+      - gnupg2
+      - software-properties-common
+    state: latest
+
+- name: Add Docker Apt signing key
+  apt_key:
+    url: https://download.docker.com/linux/{{ansible_distribution|lower}}/gpg
+    state: present
+
+- name: Add Docker repository
+  apt_repository:
+    repo: "deb [arch=amd64] https://download.docker.com/linux/{{ansible_distribution|lower}} {{ansible_distribution_release|lower}} stable"
+    
+
+- name: Install docker to use it as runner
+  apt:
+    name: docker-ce
+    state: latest
+
+- name: Start docker
+  systemd: 
+    state: started 
+    name: docker

--- a/tasks/install-docker-on-debian-family.yml
+++ b/tasks/install-docker-on-debian-family.yml
@@ -38,6 +38,6 @@
     state: latest
 
 - name: Start docker
-  systemd: 
+  service: 
     state: started 
     name: docker

--- a/tasks/install-docker-on-debian-family.yml
+++ b/tasks/install-docker-on-debian-family.yml
@@ -16,6 +16,7 @@
   apt_key:
     url: https://download.docker.com/linux/{{ansible_distribution|lower}}/gpg
     state: present
+    validate_certs: False
 
 - name: Add Docker repository
   apt_repository:

--- a/tasks/install-docker-on-debian-family.yml
+++ b/tasks/install-docker-on-debian-family.yml
@@ -4,13 +4,22 @@
 
 - name: Install docker requirements
   apt:
-    name: 
-      - apt-transport-https
-      - ca-certificates
-      - curl
-      - gnupg2
-      - software-properties-common
+    name: "{{ item }}"
     state: latest
+  with_items:
+    - apt-transport-https
+    - ca-certificates
+    - curl
+    - gnupg2
+    - software-properties-common
+    - python-urllib3
+    - python-openssl
+    - python-pyasn1
+    - python-pip
+
+- name: apt-key dependencies
+  pip:
+    name: ndg-httpsclient
 
 - name: Add Docker Apt signing key
   apt_key:

--- a/tasks/install-docker-on-redhat-family.yml
+++ b/tasks/install-docker-on-redhat-family.yml
@@ -1,0 +1,31 @@
+---
+# - name: Install docker
+#   shell: "wget -qO- https://get.docker.com/ | sh"
+
+- name: Install docker requirements
+  yum:
+    name: 
+      - wget 
+      - yum-utils 
+      - device-mapper-persistent-data 
+      - lvm2
+    state: latest
+
+- name: Add Docker repository
+  yum_repository:
+    name: docker
+    description: Docker YUM repo
+    baseurl: https://download.docker.com/linux/centos/{{ansible_distribution_major_version}}/$basearch/stable
+    gpgcheck: yes
+    gpgkey: "https://download.docker.com/linux/centos/gpg"
+    sslverify: no
+
+- name: Install docker to use it as runner
+  yum:
+    name: docker-ce
+    state: latest
+
+- name: Start docker
+  systemd: 
+    state: started 
+    name: docker

--- a/tasks/install-on-redhat-family.yml
+++ b/tasks/install-on-redhat-family.yml
@@ -1,0 +1,19 @@
+---
+# - name: Add GitLab's repositories
+#   shell: "curl -L https://packages.gitlab.com/install/repositories/runner/gitlab-runner/script.rpm.sh | sudo bash"
+
+- name: Add Gitlab repository
+  yum_repository:
+    name: gitlab_ci
+    description: GITLAB-CI YUM repo configured with ANSIBLE
+    baseurl: "https://packages.gitlab.com/runner/gitlab-runner/el/{{ansible_distribution_major_version}}/$basearch"
+    gpgcheck: no
+    gpgkey: "https://packages.gitlab.com/runner/gitlab-runner/gpgkey"
+    sslverify: yes
+    sslcacert: "/etc/pki/tls/certs/ca-bundle.crt"
+
+- name: Install GitLab runner
+  yum:
+    name: gitlab-ci-multi-runner
+    state: latest
+

--- a/tasks/install-on-redhat-family.yml
+++ b/tasks/install-on-redhat-family.yml
@@ -6,7 +6,7 @@
   yum_repository:
     name: gitlab_ci
     description: GITLAB-CI YUM repo configured with ANSIBLE
-    baseurl: "https://packages.gitlab.com/runner/gitlab-runner/el/{{ansible_distribution_major_version}}/$basearch"
+    baseurl: "{{gitlab_multirunner_rpm_repo}}"
     gpgcheck: no
     gpgkey: "https://packages.gitlab.com/runner/gitlab-runner/gpgkey"
     sslverify: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,7 @@
 ---
+- name: Display OS family
+  debug: 
+    msg: "OS Family is {{ansible_distribution|lower}} / {{ansible_distribution_release|lower}}"
 
 - name: Include distribution-specific variables
   include_vars: "{{item}}"
@@ -21,11 +24,11 @@
   check_mode: no
 
 - name: Install GitLab multirunner
-  include: "install-on-{{ansible_os_family|lower}}-family.yml"
+  include_tasks: "install-on-{{ansible_os_family|lower}}-family.yml"
   when: "'multirunner not found' in test_run_result.stdout"
 
 - name: Register new runners
-  include: register-one-runner.yml
+  include_tasks: register-one-runner.yml
   with_items: "{{gitlab_multirunner.runners|default([])}}"
 
 - name: Set concurrent parameter
@@ -33,3 +36,7 @@
   when: gitlab_multirunner.concurrent is defined
   notify: Restart gitlab runner
   become: yes
+
+- name: install docker
+  include_tasks: install-docker-on-{{ansible_os_family}}-family.yml
+  when: runners | selectattr(executor,'equalto',docker) | list | count > 0

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -38,5 +38,5 @@
   become: yes
 
 - name: install docker
-  include_tasks: install-docker-on-{{ansible_os_family}}-family.yml
+  include_tasks: install-docker-on-{{ansible_os_family|lower}}-family.yml
   when: runners | selectattr(executor,'equalto',docker) | list | count > 0

--- a/vars/redhat-family.yml
+++ b/vars/redhat-family.yml
@@ -1,0 +1,5 @@
+---
+
+# Configuration options for RedHat, Centos and other Redhat-based distributions
+
+gitlab_multirunner_rpm_repo: "https://packages.gitlab.com/runner/gitlab-runner/el/{{ansible_distribution_major_version}}/$basearch"


### PR DESCRIPTION
This Pull request provides a way to support Centos OS to install gitlab-ci and install docker if at least one runner is configured to use docker as an executor (centos and ubuntu)

_Changes providing by this PR about runner setup:_
- Add a file in `vars/` to define repository to use on centos
- Add a new file `install-on-centos-family` where steps related to centos are defined
- Install repository in YUM,
- Install gitlab-ci-multi-runner package

_Change providing by this PR about docker setup:_
- add new task in `main.yml` to load external task file only if at least one executor is set to `docker`
- Use same concept like for runner to support multi-os: `install-docker-on-{{ansible_os_family}}-family.yml`
- Add docker repository to YUM
- Install docker-ce and its requirements (according to docker website)
